### PR TITLE
FEAT: Automated guidelines publication

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Run Docker job for PDF publication
         run: |
           docker run --rm -v "$PWD:/source" --entrypoint /source/create_pdf.sh eark4all/spec-pdf-publisher
+      - name: Run Docker job for Guidelines PDF publication
+        run: |
+          docker run --rm -v "$PWD:/source" --entrypoint /source/create_guidelines_pdf.sh eark4all/spec-pdf-publisher
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Build with Jekyll docker box

--- a/create_guidelines_pdf.sh
+++ b/create_guidelines_pdf.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+echo "Generating PDF guidelines from markdown"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR" || exit
+
+cp -rf "$SCRIPT_DIR/spec-publisher/pandoc/img" "$SCRIPT_DIR/guidelines/pdf/"
+cp -rf "$SCRIPT_DIR/spec-publisher/res/md/figs" "$SCRIPT_DIR/guidelines/pdf/"
+cp -rf "$SCRIPT_DIR/guidelines/markdown/guideline/figs" "$SCRIPT_DIR/guidelines/pdf/"
+cd guidelines/pdf || exit
+
+echo " - PANDOC: Generating Preface from markdown"
+pandoc  --from gfm \
+        --to latex \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        "./preface.md" \
+        -o "./preface.tex"
+sed -i 's%section{%section*{%' ./preface.tex
+
+echo " - PANDOC: Generating Postface from markdown"
+pandoc  --from markdown \
+        --to latex \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        "$SCRIPT_DIR/guidelines/markdown/guideline/postface/postface.md" \
+        -o "./postface.tex"
+sed -i 's%section{%section*{%' ./postface.tex
+
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname "$(mktemp -u)")
+  # shellcheck source=/tmp/.venv-markdown/bin/activate
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
+
+echo " - MARKDOWN-PP: Preparing PDF markdown"
+markdown-pp PDF.md -o eark-ehealth1-guidelines-pdf.md -e tableofcontents
+echo " - MARKDOWN-PP: Preparing PDF markdown"
+
+if [ -d "$SCRIPT_DIR/site/guidelines/pdf" ]
+then
+  echo " - Removing old guidelines PDF directory"
+  rm -rf "$SCRIPT_DIR/site/guidelines/pdf"
+fi
+mkdir "$SCRIPT_DIR/site/guidelines/pdf"
+
+echo " - PANDOC: Generating Guidelines PDF document from markdown and Tex sources"
+pandoc  --from markdown \
+        --template "$SCRIPT_DIR/spec-publisher/pandoc/templates/eisvogel.latex" \
+        --listings \
+        --table-of-contents \
+        --metadata-file "$SCRIPT_DIR/spec-publisher/pandoc/metadata.yaml" \
+        --include-before-body "./preface.tex" \
+        --include-after-body "./postface.tex" \
+        --number-sections \
+        -o "$SCRIPT_DIR/site/guidelines/pdf/eark-cits-ehealth1-guidelines.pdf" \
+        eark-ehealth1-guidelines-pdf.md
+
+echo " - Finished"

--- a/create_site.sh
+++ b/create_site.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR" || exit
 
 echo " - Cleaning up site directory and copying spec-publisher site..."
-# git clean -f doc/ site/ specification/
+git clean -f doc/ site/ specification/
 cp specification/postface/postface.md doc/site/
 cp -rf spec-publisher/site/* site/
 cp -rf spec-publisher/res/md/figs site/
@@ -26,6 +26,36 @@ markdown-pp body.md -o body_toc.md
 
 echo " - MARKDOWN-PP: generating site index.md..."
 markdown-pp SITE.md -o ../../site/index.md
+
+cd "$SCRIPT_DIR" || exit
+
+echo " - Cleaning up guidelines directory..."
+if [ -d "$SCRIPT_DIR/site/guidelines" ]
+then
+  echo " - Removing old site guidelines directory"
+  rm -rf "$SCRIPT_DIR/site/guidelines"
+fi
+mkdir "$SCRIPT_DIR/site/guidelines"
+mkdir "$SCRIPT_DIR/site/guidelines/pdf"
+git clean -f guidelines/
+cp guidelines/markdown/guideline/postface/postface.md guidelines/site/
+cp -rf spec-publisher/res/md/figs site/guidelines/
+cp -rf guidelines/markdown/guideline/figs site/guidelines/
+
+echo " - Generating guidelines site and PDF markdown..."
+java -jar ./spec-publisher/target/mets-profile-processor-0.2.0-SNAPSHOT.jar -f ./guidelines/guidelines.yaml -o guidelines/site
+
+echo " - MARKDOWN-PP: generating guidelines page with TOC..."
+cd guidelines/site || exit
+bash "$SCRIPT_DIR/spec-publisher/scripts/create-venv.sh"
+command -v markdown-pp >/dev/null 2>&1 || {
+  tmpdir=$(dirname "$(mktemp -u)")
+  source "$tmpdir/.venv-markdown/bin/activate"
+}
+markdown-pp body.md -o body_toc.md
+
+echo " - MARKDOWN-PP: generating guidelines index.md..."
+markdown-pp SITE.md -o ../../site/guidelines/index.md
 
 cd "$SCRIPT_DIR" || exit
 

--- a/site/_data/navbar.yml
+++ b/site/_data/navbar.yml
@@ -13,7 +13,7 @@
     - subtitle: "HTML"
       subextref: "/guidelines/"
     - subtitle: "PDF"
-      subextref: "/guidelines/pdf/eark-cits-ehealth1.pdf"
+      subextref: "/guidelines/pdf/eark-cits-ehealth1-guidelines.pdf"
 
 - title: "Schema"
   href: "/schema/"

--- a/site/_data/navbar.yml
+++ b/site/_data/navbar.yml
@@ -13,7 +13,7 @@
     - subtitle: "HTML"
       subextref: "/guidelines/"
     - subtitle: "PDF"
-      subextref: "/guidelines/pdf/"
+      subextref: "/guidelines/pdf/eark-cits-ehealth1.pdf"
 
 - title: "Schema"
   href: "/schema/"

--- a/site/_data/navbar.yml
+++ b/site/_data/navbar.yml
@@ -7,6 +7,14 @@
 - title: "Profile"
   href: "/profile/"
 
+- title: "Guidelines"
+  href: "/"
+  subcategories:
+    - subtitle: "HTML"
+      subextref: "/guidelines/"
+    - subtitle: "PDF"
+      subextref: "/guidelines/pdf/"
+
 - title: "Schema"
   href: "/schema/"
 


### PR DESCRIPTION
- extended `create_site.sh` to generate the guidelines publication;
- added `create_guidelines_pdf.sh` to generate the PDF version of the guidelines;
- added guidelines entries to the menu in `site/_data/navbar.yml`;
- updated `spec-publisher` to handle no profile publications; and
- added entry for the guidelines publication to `.github/workflows/jekyll-gh-pages.yml`.